### PR TITLE
daml-react-hooks: Stop useQuery from reloading indefinitely

### DIFF
--- a/ui/src/components/MainView.tsx
+++ b/ui/src/components/MainView.tsx
@@ -10,7 +10,7 @@ const MainView: React.FC = () => {
   const party = useParty();
   const myUserResult = useFetchByKey(User, () => party, [party]);
   const myUser = myUserResult.contract?.payload;
-  const allUsersResult = useQuery(User, () => ({}), []);
+  const allUsersResult = useQuery(User);
   const allUsers = allUsersResult.contracts.map((user) => user.payload);
   const reload = useReload();
 

--- a/ui/src/daml-react-hooks/hooks.ts
+++ b/ui/src/daml-react-hooks/hooks.ts
@@ -25,16 +25,18 @@ const loadQuery = async <T extends object>(state: DamlLedgerState, template: Tem
   state.dispatch(setQueryResult(template, query, contracts));
 }
 
-const emptyQueryFactory = <T extends object>(): Query<T> => ({} as Query<T>);
-
 export type QueryResult<T extends object, K> = {
   contracts: CreateEvent<T, K>[];
   loading: boolean;
 }
 
+// NOTE(MH): Since `{} !== {}`, we need a stable reference to `{}` for `useMemo`
+// to work in `useQuery` when using the default value for `queryFactory`.
+const emptyQuery = {};
+
 /// React Hook for a query against the `/contracts/search` endpoint of the JSON API.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const useQuery = <T extends object, K>(template: Template<T, K>, queryFactory: () => Query<T> = emptyQueryFactory, queryDeps?: readonly any[]): QueryResult<T, K> => {
+export const useQuery = <T extends object, K>(template: Template<T, K>, queryFactory: () => Query<T> = () => emptyQuery as Query<T>, queryDeps?: readonly any[]): QueryResult<T, K> => {
   const state = useDamlState();
   const query = useMemo(queryFactory, queryDeps);
   const contracts = LedgerStore.getQueryResult(state.store, template, query);


### PR DESCRIPTION
Since `{} !== {}` in JavaScript, the `useQuery` hook used to indefinitely
reload all contracts when called without its second and third parameter.
Having a stable name for `{}` fixes the issue. Manual tests confirm this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/create-daml-app/10)
<!-- Reviewable:end -->
