### PR TITLE
Remove ensure clause in User template

### DIFF
--- a/daml/User.daml
+++ b/daml/User.daml
@@ -17,7 +17,8 @@ template User with
         friend: Party
       controller username
       do
-        assert $ friend `notElem` (username :: friends)
+        assertMsg "You cannot add yourself as a friend" (friend /= username)
+        assertMsg "You cannot add a friend twice" (friend `notElem` friends)
         create this with friends = sort (friend :: friends)
 
     nonconsuming choice RemoveFriend: ContractId User with

--- a/daml/User.daml
+++ b/daml/User.daml
@@ -9,7 +9,6 @@ template User with
   where
     signatory username
     observer friends
-    ensure username `notElem` friends
 
     key username: Party
     maintainer key
@@ -18,7 +17,7 @@ template User with
         friend: Party
       controller username
       do
-        assert $ friend `notElem` friends
+        assert $ friend `notElem` (username :: friends)
         create this with friends = sort (friend :: friends)
 
     nonconsuming choice RemoveFriend: ContractId User with

--- a/daml/User.daml
+++ b/daml/User.daml
@@ -9,7 +9,7 @@ template User with
   where
     signatory username
     observer friends
-    ensure username `notElem` friends && dedupSort friends == friends
+    ensure username `notElem` friends
 
     key username: Party
     maintainer key


### PR DESCRIPTION
The check that the friend list is sorted was overkill I think. The check that new friends added are not the same as the user is done as an assert in the AddFriend choice instead.

Fixes https://github.com/digital-asset/daml/issues/4297.