### PR TITLE
Remove icons from friends panel, add button for adding friends

### DIFF
--- a/ui/src/components/MainView.tsx
+++ b/ui/src/components/MainView.tsx
@@ -32,9 +32,6 @@ const MainView: React.FC = () => {
     }
   }
 
-  const messageFriend = (friend: Party) =>
-    alert('Messaging parties is not yet implemented.');
-
   return (
     <Container>
       <Grid centered columns={2}>
@@ -56,7 +53,6 @@ const MainView: React.FC = () => {
               <PartyListEdit
                 parties={myUser?.friends ?? []}
                 onAddParty={addFriend}
-                onMessageParty={messageFriend}
               />
             </Segment>
             <Segment>

--- a/ui/src/components/PartyListEdit.tsx
+++ b/ui/src/components/PartyListEdit.tsx
@@ -43,7 +43,7 @@ const PartyListEdit: React.FC<Props> = ({parties, onAddParty}) => {
           readOnly={isSubmitting}
           loading={isSubmitting}
           size='small'
-          placeholder='Name'
+          placeholder="Friend's name"
           value={newParty}
           onChange={(event) => setNewParty(event.currentTarget.value)}
         />

--- a/ui/src/components/PartyListEdit.tsx
+++ b/ui/src/components/PartyListEdit.tsx
@@ -29,7 +29,9 @@ const PartyListEdit: React.FC<Props> = ({parties, onAddParty}) => {
   return (
     <List relaxed>
       {[...parties].sort((x, y) => x.localeCompare(y)).map((party) =>
-        <List.Item>
+        <List.Item
+          key={party}
+        >
           <List.Icon name='user outline' />
           <List.Content>
             <List.Header>{party}</List.Header>

--- a/ui/src/components/PartyListEdit.tsx
+++ b/ui/src/components/PartyListEdit.tsx
@@ -5,13 +5,12 @@ import { Party } from '@daml/types';
 type Props = {
   parties: Party[];
   onAddParty: (party: Party) => Promise<boolean>;
-  onMessageParty: (party: Party) => void;
 }
 
 /**
  * React component to edit a list of `Party`s.
  */
-const PartyListEdit: React.FC<Props> = ({parties, onAddParty, onMessageParty}) => {
+const PartyListEdit: React.FC<Props> = ({parties, onAddParty}) => {
   const [newParty, setNewParty] = React.useState('');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
 

--- a/ui/src/components/PartyListEdit.tsx
+++ b/ui/src/components/PartyListEdit.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { Form, Input, List } from 'semantic-ui-react';
-import ListActionItem from './ListActionItem';
+import { Form, List, Button } from 'semantic-ui-react';
 import { Party } from '@daml/types';
 
 type Props = {
@@ -31,38 +30,26 @@ const PartyListEdit: React.FC<Props> = ({parties, onAddParty, onMessageParty}) =
   return (
     <List relaxed>
       {[...parties].sort((x, y) => x.localeCompare(y)).map((party) =>
-        <ListActionItem
-          key={party}
-          icon='user outline'
-          action={{
-            icon: 'comment alternate',
-            onClick: () => onMessageParty(party)
-          }}
-        >
-          <List.Header>{party}</List.Header>
-        </ListActionItem>
+        <List.Item>
+          <List.Icon name='user outline' />
+          <List.Content>
+            <List.Header>{party}</List.Header>
+          </List.Content>
+        </List.Item>
       )}
-      <ListActionItem
-        key='add friend'
-        icon='user outline'
-        action={{
-          icon: 'add user',
-          onClick: () => addParty(),
-        }}
-      >
-        <Form onSubmit={addParty}>
-          <Input
-            fluid
-            transparent
-            readOnly={isSubmitting}
-            loading={isSubmitting}
-            size='small'
-            placeholder='Add friend'
-            value={newParty}
-            onChange={(event) => setNewParty(event.currentTarget.value)}
-          />
-        </Form>
-      </ListActionItem>
+      <br />
+      <Form onSubmit={addParty}>
+        <Form.Input
+          fluid
+          readOnly={isSubmitting}
+          loading={isSubmitting}
+          size='small'
+          placeholder='Name'
+          value={newParty}
+          onChange={(event) => setNewParty(event.currentTarget.value)}
+        />
+        <Button type='submit'>Add Friend</Button>
+      </Form>
     </List>
   );
 };

--- a/ui/src/components/PartyListEdit.tsx
+++ b/ui/src/components/PartyListEdit.tsx
@@ -42,7 +42,6 @@ const PartyListEdit: React.FC<Props> = ({parties, onAddParty}) => {
           fluid
           readOnly={isSubmitting}
           loading={isSubmitting}
-          size='small'
           placeholder="Friend's name"
           value={newParty}
           onChange={(event) => setNewParty(event.currentTarget.value)}


### PR DESCRIPTION
I've left the 'add friend' icons in the network panel as I think it's a pretty useful way to grow a network quickly.