### PR TITLE
Don't use infix function

### DIFF
--- a/.dlint.yaml
+++ b/.dlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Use infix }

--- a/daml/User.daml
+++ b/daml/User.daml
@@ -25,7 +25,7 @@ template User with
         content: Text
       controller sender
       do
-        assertMsg "You must be a friend to send a message" (sender `elem` friends)
+        assertMsg "You must be a friend to send a message" (elem sender friends)
         create Message with sender, receiver = username, content
 
 template Message with


### PR DESCRIPTION
Using `elem` prefix triggers a dlint warning so we add the dlint.yaml file. We might want to disable the "Use infix" rule globally but for now we just ignore it locally.