### PR TITLE
Add dlint.yaml file

### DIFF
--- a/.dlint.yaml
+++ b/.dlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Use infix }


### PR DESCRIPTION
Forgot that we need this in master so when you implement the messaging feature you don't see the dlint warning.