### PR TITLE
Allow yarn test from the root directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "workspaces": [
     "daml-ts",
     "ui"
-  ]
+  ],
+  "scripts": {
+    "test": "yarn workspace create-daml-app run test"
+  }
 }


### PR DESCRIPTION
If you open VS Code in the root of the repo and have the jest extension
installed, you'll get some nasty error message without this.

The ultimate plan is to move away from yarn workspaces. Until then,
let's keep this workaround in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/create-daml-app/56)
<!-- Reviewable:end -->
