### PR TITLE
Clean up browser-based testing

### DIFF
--- a/ui/src/components/LoginScreen.tsx
+++ b/ui/src/components/LoginScreen.tsx
@@ -84,9 +84,14 @@ const LoginScreen: React.FC<Props> = ({onLogin}) => {
                   iconPosition='left'
                   placeholder='Username'
                   value={username}
+                  className='test-select-username-field'
                   onChange={e => setUsername(e.currentTarget.value)}
                 />
-                <Button primary fluid onClick={handleLogin}>
+                <Button
+                  primary
+                  fluid
+                  className='test-select-login-button'
+                  onClick={handleLogin}>
                   Log in
                 </Button>
               </>

--- a/ui/src/components/MainScreen.tsx
+++ b/ui/src/components/MainScreen.tsx
@@ -24,7 +24,7 @@ const MainScreen: React.FC<Props> = ({onLogout}) => {
             size='mini'
           />
         </Menu.Item>
-        <Menu.Menu position='right' className='menu'>
+        <Menu.Menu position='right' className='test-select-main-menu'>
           <Menu.Item position='right'>
             You are logged in as {useParty()}.
           </Menu.Item>


### PR DESCRIPTION
- Select elements using more specific CSS class names
- Close the browser page (seems to fix what I thought was a Puppeteer
issue)
- Abstract out the party names slightly and leave comment about party
management service
- Remove use of `waitForSelector` which I think is unnecessary