### PR TITLE
Increase timeout for startup beforeAll tests

### DIFF
--- a/ui/src/index.test.tsx
+++ b/ui/src/index.test.tsx
@@ -55,7 +55,7 @@ beforeAll(async () => {
 
   // Launch a browser once for all tests.
   browser = await puppeteer.launch();
-}, 20_000);
+}, 30_000);
 
 afterAll(async () => {
   // Kill the `daml start` and `yarn start` processes.


### PR DESCRIPTION
The Jest timeout was hit in CI for the commit in master. It's possible that the CI server is slower than my machine so I'm increasing the timeout. Let's see if this passes.