### PR TITLE
Remove the daml-start.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ yarn workspaces run build
 To start the application, there are again two steps.
 First start a DAML ledger using
 ```
-./daml-start.sh
+daml start --start-navigator=no
 ```
+(We're not using DAML Navigator here, hence we don't start it.)
 This must continue running to serve ledger requests.
 
 Then in another terminal window, start the UI server via

--- a/daml-start.sh
+++ b/daml-start.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-daml start \
-  --open-browser=no \
-  --start-navigator=no \
-  --sandbox-option=--wall-clock-time \
-  --sandbox-option='--ledgerid=create-daml-app-sandbox' \
-  $*

--- a/daml.yaml
+++ b/daml.yaml
@@ -10,3 +10,6 @@ dependencies:
 - daml-prim
 - daml-stdlib
 - daml-trigger
+sandbox-options:
+- --wall-clock-time
+- --ledgerid=create-daml-app-sandbox

--- a/ui/src/index.test.tsx
+++ b/ui/src/index.test.tsx
@@ -7,7 +7,6 @@ import { computeCredentials } from './Credentials';
 
 import puppeteer, { Browser, Page } from 'puppeteer';
 
-const LEDGER_ID = 'create-daml-app-sandbox';
 const SANDBOX_PORT = 6865;
 const JSON_API_PORT = 7575;
 const UI_PORT = 3000;
@@ -39,20 +38,11 @@ test('Party names are unique', async () => {
 // Use a single sandbox, JSON API server and browser for all tests for speed.
 // This means we need to use a different set of parties and a new browser page for each test.
 beforeAll(async () => {
-  // Use `daml start` to start up the sandbox and json api server.
-  // This is what we recommend to our users (over running the two processes separately),
-  // so we replicate it in these tests.
-  const startArgs = [
-    'start',
-    '--open-browser=no',
-    '--start-navigator=no',
-    '--sandbox-option=--wall-clock-time',
-    `--sandbox-option=--ledgerid=${LEDGER_ID}`,
-  ];
-  // Run `daml start` from create-daml-app root dir.
+  // Run `daml start --start-navigator=no` to start up the sandbox and json api server.
+  // Run it from the repository root, where the `daml.yaml` lives.
   // The path should already include '.daml/bin' in the environment where this is run.
   const startOpts: SpawnOptions = { cwd: '..', stdio: 'inherit' };
-  startProc = spawn('daml', startArgs, startOpts);
+  startProc = spawn('daml', ['start', '--start-navigator=no'], startOpts);
 
   // Run `yarn start` in another shell.
   // Disable automatically opening a browser using the env var described here:


### PR DESCRIPTION
DAML Assistant now supports passing the flags we want to pass to sandbox
via the `daml.yaml` file. Hence, there's no more need for the script,
which never worked on Windows anyway, and removing it makes the repo
cleaner.

This fixes https://github.com/digital-asset/daml/issues/4295
and is part of https://github.com/digital-asset/daml/issues/4866

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digital-asset/create-daml-app/78)
<!-- Reviewable:end -->
