### PR TITLE
Fix leaking processes from `yarn start`

### DIFF
--- a/ui/src/index.test.tsx
+++ b/ui/src/index.test.tsx
@@ -50,7 +50,8 @@ beforeAll(async () => {
   const env = {...process.env, BROWSER: 'none'};
   uiProc = spawn('yarn', ['start'], { env, stdio: 'inherit', detached: true});
   // Note(kill-yarn-start): The `detached` flag starts the process in a new process group.
-  // This allows us to kill the process with all its descendents after the tests finish.
+  // This allows us to kill the process with all its descendents after the tests finish,
+  // following https://azimi.me/2014/12/31/kill-child_process-node-js.html.
 
   // We know the `daml start` and `yarn start` servers are ready once the relevant ports become available.
   await waitOn({resources: [

--- a/ui/src/index.test.tsx
+++ b/ui/src/index.test.tsx
@@ -67,7 +67,7 @@ afterAll(async () => {
   // Kill the `daml start` process.
   // Note that `kill()` sends the `SIGTERM` signal but the actual processes may
   // not die immediately.
-  // TODO: Test/fix this for windows.
+  // TODO: Test this on Windows.
   if (startProc) {
     startProc.kill();
   }
@@ -75,6 +75,7 @@ afterAll(async () => {
   // Kill the `yarn start` process including all its descendents.
   // The `-` indicates to kill all processes in the process group.
   // See Note(kill-yarn-start).
+  // TODO: Test this on Windows.
   if (uiProc) {
     process.kill(-uiProc.pid)
   }

--- a/ui/src/index.test.tsx
+++ b/ui/src/index.test.tsx
@@ -48,7 +48,9 @@ beforeAll(async () => {
   // Disable automatically opening a browser using the env var described here:
   // https://github.com/facebook/create-react-app/issues/873#issuecomment-266318338
   const env = {...process.env, BROWSER: 'none'};
-  uiProc = spawn('yarn', ['start'], { env, stdio: 'inherit' });
+  uiProc = spawn('yarn', ['start'], { env, stdio: 'inherit', detached: true});
+  // Note(kill-yarn-start): The `detached` flag starts the process in a new process group.
+  // This allows us to kill the process with all its descendents after the tests finish.
 
   // We know the `daml start` and `yarn start` servers are ready once the relevant ports become available.
   await waitOn({resources: [
@@ -62,15 +64,19 @@ beforeAll(async () => {
 }, 40_000);
 
 afterAll(async () => {
-  // Kill the `daml start` and `yarn start` processes.
+  // Kill the `daml start` process.
   // Note that `kill()` sends the `SIGTERM` signal but the actual processes may
   // not die immediately.
   // TODO: Test/fix this for windows.
   if (startProc) {
     startProc.kill();
   }
+
+  // Kill the `yarn start` process including all its descendents.
+  // The `-` indicates to kill all processes in the process group.
+  // See Note(kill-yarn-start).
   if (uiProc) {
-    uiProc.kill();
+    process.kill(-uiProc.pid)
   }
 
   if (browser) {


### PR DESCRIPTION
Previously `yarn test` would shell out to `yarn start` before all tests and afterwards kill that process. However this did not kill the child and descendent processes.

Now we use [this](https://azimi.me/2014/12/31/kill-child_process-node-js.html) method to kill all descendent processes: running `yarn start` in a new process group and then killing everything in that group.